### PR TITLE
[fix] spring으로부터 받은 입력을 json으로 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Pipfile.*
 .DS_Store
+*.pyc

--- a/spellCheckerApi/views.py
+++ b/spellCheckerApi/views.py
@@ -29,7 +29,7 @@ def jobKoreaSpellChecker(request):
 @csrf_exempt
 def incruitSpellChecker(request):
     # request.body를 읽어 문자열로 변환합니다.
-    body_str = request.body.decode('utf-8')
+    body_str = json.loads(request.body.decode('utf-8'))
     result = incruit_spell_checker.check(body_str)
 
     # 처리 결과를 JSON으로 반환합니다.

--- a/spell_checker/incruit_spell_checker.py
+++ b/spell_checker/incruit_spell_checker.py
@@ -88,6 +88,7 @@ def parse_html(response, originText):
     
     
 def check(val):
+    val = val['text']
     if not val:
         return {'result': False, 'message': 'check your text'}
     


### PR DESCRIPTION
incruit 맞춤법 검사기의 문제는 스프링으로부터 받은 문단이 json이였습니다.
json.loads() 함수를 사용해서 처리하니 정상적으로 작동하였습니다.